### PR TITLE
Force MM to use market fees

### DIFF
--- a/site/pages/_app.js
+++ b/site/pages/_app.js
@@ -1,9 +1,26 @@
 import '../styles/index.css'
-import { Web3ReactProvider } from '@web3-react/core'
-import Web3 from 'web3'
-import Big from 'big.js'
 
-const getLibrary = provider => new Web3(provider)
+import { Web3ReactProvider } from '@web3-react/core'
+import Big from 'big.js'
+import Web3 from 'web3'
+
+function getLibrary(provider) {
+  if (provider.isMetaMask) {
+    // To force MetaMask to use market suggested fees, we must intercept the
+    // calls to request() with method eth_sendTransaction and clear out the gas
+    // price property. ¯\_(ツ)_/¯
+    // Note; This may not work with newer versions of Web3. Tested with v1.3.0.
+    const request = provider.request.bind(provider)
+    const wrappedRequest = function ({ method, params }) {
+      if (method === 'eth_sendTransaction' && params[0]?.gasPrice) {
+        params[0].gasPrice = undefined
+      }
+      return request({ method, params })
+    }
+    provider.request = wrappedRequest
+  }
+  return new Web3(provider)
+}
 
 Big.RM = 0
 


### PR DESCRIPTION
Clearing the `gas` parameter before sending a transaction is not enough to force MetaMask use the market fees. The key to do so is to clear the `gasPrice` parameter instead. But Web3 will try to repopulate that field before sending the call to `eth_sendTransaction`, invalidating any change we can do "client side". Therefore, the clean-up has to be done "below" Web3 and before MetaMask: at the provider level.

This PR patches the provider, if it is coming MetaMask, so when a transaction is sent, the gas price is properly cleared. After this change MM properly offers the market fees.

Resolves #45