### PR TITLE
ci: pin actions to full-length commit hashes

### DIFF
--- a/.github/workflows/aws-eb-deploy.yml
+++ b/.github/workflows/aws-eb-deploy.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: bloq/actions/setup-node-env@v1
+      - uses: bloq/actions/setup-node-env@7a00bde576f8383a7afabf48dc6153bd7a7daab7 # v1.6.0
       - run: |
           sudo apt-get update
           sudo apt-get install -y python3-pip
           pip3 install --upgrade awsebcli==3.21.0
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -10,4 +10,4 @@ concurrency:
 
 jobs:
   run-checks:
-    uses: bloq/actions/.github/workflows/js-checks.yml@v1
+    uses: bloq/actions/.github/workflows/js-checks.yml@7a00bde576f8383a7afabf48dc6153bd7a7daab7 # v1.6.0


### PR DESCRIPTION
This pull request pins all GitHub Actions to their full-length commit SHAs. Used GitHub Actions have not been updated, and have been pinned to commit hashes for the latest release matching the existing tag.

The organisation-level setting "Require actions to be pinned to a full-length commit SHA" will be enabled on **January 15th, 2026**. Once this setting is active, any workflows referencing actions by tag (e.g., `@v4`) or branch (e.g., `@master`) will fail to execute.

Additionally, the setting "Allow hemilabs, and select non-hemilabs, actions and reusable workflows" will be enabled on the same date. All third-party actions currently in use by this repository have been recorded and will be permitted. **After January 15th, 2026, any new third-party actions must be approved by SecOps before use.**

Pinning actions to immutable commit hashes reduces potential for supply chain attacks by:
- Tag mutation attacks (where a malicious actor overwrites a tag with compromised code)
- Unexpected changes from upstream action updates

For more information, please see:

- [GitHub Docs: Secure use reference - Pin actions to a full-length commit SHA](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)
- [GitHub Well-Architected: Securing GitHub Actions Workflows](https://wellarchitected.github.com/library/application-security/recommendations/actions-security/)
- [GitHub Blog: Actions policy now supports blocking and SHA pinning](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)

All original version tags are preserved as inline comments for maintainability.

---

This pull request does not update any actions. All actions have been pinned to the most recent commit for the pre-existing tag -- please update actions in a separate pull request if necessary. Pinned actions:

| Action                                         | Update | Change                   |
|------------------------------------------------|--------|--------------------------|
| `actions/checkout`                             | pin    | `v4 -> v4.3.1 (34e1148)` |
| `aws-actions/configure-aws-credentials`        | pin    | `v4 -> v4.3.1 (7474bc4)` |
| `bloq/actions/.github/workflows/js-checks.yml` | pin    | `v1 -> v1.6.0 (7a00bde)` |
| `bloq/actions/setup-node-env`                  | pin    | `v1 -> v1.6.0 (7a00bde)` |

Detected third-party actions:

```
aws-actions/configure-aws-credentials@v4.3.1
bloq/actions/.github/workflows/js-checks.yml@v1.6.0
bloq/actions/setup-node-env@v1.6.0
```